### PR TITLE
Add calendar page and routing

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -43,17 +43,3 @@ hr {
   margin: 1rem 0;
 }
 
-/* Main image styling */
-.main-images {
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
-  padding: 1rem 2rem;
-}
-
-.main-images img {
-  width: 48%;
-  height: auto;
-  object-fit: cover;
-  border-radius: 8px;
-}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,11 +1,13 @@
 <div class="top-bar">
   <div class="nav-left">
-    <a href="#">Calender</a>
+    <a routerLink="/calenders">Calender</a>
     <a href="#">Menu</a>
     <a href="#">Hours</a>
   </div>
 
-  <img src="assets/lucky-joes-logo.png" alt="Lucky Joe's Logo" class="logo" />
+  <a routerLink="/">
+    <img src="assets/lucky-joes-logo.png" alt="Lucky Joe's Logo" class="logo" />
+  </a>
 
   <div class="nav-right">
     <a href="#">Photos</a>
@@ -20,7 +22,4 @@
 
 <hr />
 
-<div class="main-images">
-  <img src="assets/bar-left.jpg" alt="Lucky Joe's Bar Left" />
-  <img src="assets/bar-right.jpg" alt="Lucky Joe's Bar Right" />
-</div>
+<router-outlet></router-outlet>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,8 @@
 import { Routes } from '@angular/router';
+import { Home } from './home';
+import { Calenders } from './calenders';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: Home },
+  { path: 'calenders', component: Calenders }
+];

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -14,10 +14,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render calender link', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, lucky-joes-site');
+    expect(compiled.querySelector('.nav-left a')?.textContent).toContain('Calender');
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, RouterLink],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/calenders.css
+++ b/src/app/calenders.css
@@ -1,0 +1,7 @@
+h2 {
+  font-family: monospace;
+}
+
+p {
+  font-family: monospace;
+}

--- a/src/app/calenders.html
+++ b/src/app/calenders.html
@@ -1,0 +1,2 @@
+<h2>Upcoming Events</h2>
+<p>Check back soon for our event schedule!</p>

--- a/src/app/calenders.ts
+++ b/src/app/calenders.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-calenders',
+  standalone: true,
+  templateUrl: './calenders.html',
+  styleUrl: './calenders.css'
+})
+export class Calenders {}

--- a/src/app/home.css
+++ b/src/app/home.css
@@ -1,0 +1,13 @@
+.main-images {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1rem 2rem;
+}
+
+.main-images img {
+  width: 48%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 8px;
+}

--- a/src/app/home.html
+++ b/src/app/home.html
@@ -1,0 +1,4 @@
+<div class="main-images">
+  <img src="assets/bar-left.jpg" alt="Lucky Joe's Bar Left" />
+  <img src="assets/bar-right.jpg" alt="Lucky Joe's Bar Right" />
+</div>

--- a/src/app/home.ts
+++ b/src/app/home.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  templateUrl: './home.html',
+  styleUrl: './home.css'
+})
+export class Home {}


### PR DESCRIPTION
## Summary
- create standalone components for Home and Calenders
- move main images to Home component
- add RouterLink usage in top bar and wrap logo with home link
- configure routes for Home and Calenders
- update tests accordingly

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e16f60d3483278eae0aab88a8462b