### PR TITLE
Add basic calendar display

### DIFF
--- a/src/app/calenders.css
+++ b/src/app/calenders.css
@@ -1,7 +1,35 @@
 h2 {
   font-family: monospace;
+  text-align: center;
 }
 
-p {
+.calendar-nav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 1rem;
   font-family: monospace;
+}
+
+.calendar-nav button {
+  margin: 0 1rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.calendar {
+  border-collapse: collapse;
+  width: 100%;
+  font-family: monospace;
+}
+
+.calendar th,
+.calendar td {
+  border: 1px solid #ddd;
+  text-align: center;
+  padding: 4px;
+  width: 14.28%;
+}
+
+.other-month {
+  color: #aaa;
 }

--- a/src/app/calenders.html
+++ b/src/app/calenders.html
@@ -1,2 +1,27 @@
-<h2>Upcoming Events</h2>
-<p>Check back soon for our event schedule!</p>
+<h2>Calendar</h2>
+
+<div class="calendar-nav">
+  <button (click)="previousMonth()">Prev</button>
+  <span>{{ monthLabel }}</span>
+  <button (click)="nextMonth()">Next</button>
+</div>
+
+<table class="calendar">
+  <thead>
+    <tr>
+      <th *ngFor="let day of ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']">
+        {{ day }}
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let week of weeks">
+      <td
+        *ngFor="let day of week"
+        [class.other-month]="day.getMonth() !== currentDate.getMonth()"
+      >
+        {{ day.getDate() }}
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/app/calenders.ts
+++ b/src/app/calenders.ts
@@ -6,4 +6,53 @@ import { Component } from '@angular/core';
   templateUrl: './calenders.html',
   styleUrl: './calenders.css'
 })
-export class Calenders {}
+export class Calenders {
+  currentDate = new Date();
+
+  get monthLabel(): string {
+    return this.currentDate.toLocaleString('default', {
+      month: 'long',
+      year: 'numeric',
+    });
+  }
+
+  get weeks(): Date[][] {
+    return this.buildCalendar(this.currentDate);
+  }
+
+  previousMonth(): void {
+    this.currentDate = new Date(
+      this.currentDate.getFullYear(),
+      this.currentDate.getMonth() - 1,
+      1
+    );
+  }
+
+  nextMonth(): void {
+    this.currentDate = new Date(
+      this.currentDate.getFullYear(),
+      this.currentDate.getMonth() + 1,
+      1
+    );
+  }
+
+  private buildCalendar(date: Date): Date[][] {
+    const first = new Date(date.getFullYear(), date.getMonth(), 1);
+    const last = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+
+    const weeks: Date[][] = [];
+    const start = new Date(first);
+    start.setDate(first.getDate() - first.getDay());
+
+    const current = new Date(start);
+    while (current <= last || current.getDay() !== 0) {
+      const week: Date[] = [];
+      for (let i = 0; i < 7; i++) {
+        week.push(new Date(current));
+        current.setDate(current.getDate() + 1);
+      }
+      weeks.push(week);
+    }
+    return weeks;
+  }
+}


### PR DESCRIPTION
## Summary
- implement interactive calendar component
- replace placeholder HTML content with month view
- style and lay out calendar table

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684e1adff838832787ab8d7bc0bf51cd