### PR TITLE
Fix Calendar ngFor error

### DIFF
--- a/src/app/calenders.ts
+++ b/src/app/calenders.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { NgFor } from '@angular/common';
 
 @Component({
   selector: 'app-calenders',
   standalone: true,
+  imports: [NgFor],
   templateUrl: './calenders.html',
   styleUrl: './calenders.css'
 })


### PR DESCRIPTION
## Summary
- add NgFor import to `Calenders` component

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684e1c191c688327829c582f87bb154b