### PR TITLE
Improve calendar UI

### DIFF
--- a/src/app/calenders.css
+++ b/src/app/calenders.css
@@ -20,6 +20,10 @@ h2 {
   border-collapse: collapse;
   width: 100%;
   font-family: monospace;
+  max-width: 500px;
+  margin: auto;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
 }
 
 .calendar th,
@@ -28,8 +32,25 @@ h2 {
   text-align: center;
   padding: 4px;
   width: 14.28%;
+  cursor: pointer;
 }
 
 .other-month {
   color: #aaa;
+}
+
+.today {
+  background-color: #f2f2f2;
+  font-weight: bold;
+}
+
+.selected {
+  background-color: #4caf50;
+  color: #fff;
+}
+
+.selected-info {
+  text-align: center;
+  margin-top: 0.5rem;
+  font-family: monospace;
 }

--- a/src/app/calenders.html
+++ b/src/app/calenders.html
@@ -19,9 +19,14 @@
       <td
         *ngFor="let day of week"
         [class.other-month]="day.getMonth() !== currentDate.getMonth()"
+        [class.today]="isToday(day)"
+        [class.selected]="isSelected(day)"
+        (click)="selectDate(day)"
       >
         {{ day.getDate() }}
       </td>
     </tr>
   </tbody>
 </table>
+
+<p *ngIf="selectedDate" class="selected-info">Selected: {{ selectedDate | date:'fullDate' }}</p>

--- a/src/app/calenders.ts
+++ b/src/app/calenders.ts
@@ -10,6 +10,7 @@ import { NgFor } from '@angular/common';
 })
 export class Calenders {
   currentDate = new Date();
+  selectedDate: Date | null = null;
 
   get monthLabel(): string {
     return this.currentDate.toLocaleString('default', {
@@ -36,6 +37,21 @@ export class Calenders {
       this.currentDate.getMonth() + 1,
       1
     );
+  }
+
+  selectDate(date: Date): void {
+    this.selectedDate = date;
+  }
+
+  isSelected(date: Date): boolean {
+    return (
+      this.selectedDate?.toDateString() === date.toDateString()
+    );
+  }
+
+  isToday(date: Date): boolean {
+    const today = new Date();
+    return today.toDateString() === date.toDateString();
   }
 
   private buildCalendar(date: Date): Date[][] {


### PR DESCRIPTION
## Summary
- make calendar table more interactive and professional
- allow date selection and highlight today

## Testing
- `npm test` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_684e1d5f9bc08327bd502016c7a0de0c