### PR TITLE
Add home link to logo

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -5,7 +5,9 @@
     <a href="#">Hours</a>
   </div>
 
-  <img src="lucky-joes-logo.png" />
+  <a routerLink="/">
+    <img src="lucky-joes-logo.png" class="logo" />
+  </a>
 
   <div class="nav-right">
     <a href="#">Photos</a>


### PR DESCRIPTION
## Summary
- wrap the site logo in a routerLink so clicking it returns to the home page

## Testing
- `npm test` *(fails: no Chrome binary found)*

------
https://chatgpt.com/codex/tasks/task_e_684e24be18108327bc38cb301a7272b8