### PR TITLE
Add embedded calendar page

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -12,6 +12,7 @@
           <a href="#">Merch</a>
           <a routerLink="/menu">Menu</a>
           <a routerLink="/drinks">Drinks</a>
+          <a routerLink="/calendar">Calendar</a>
         </div>
         <div class="nav-right">
           <a href="#">Events</a>
@@ -31,6 +32,7 @@
         <a href="#">Hours</a>
         <a href="#">Events</a>
         <a href="#">Food</a>
+        <a routerLink="/calendar">Calendar</a>
       </div>
     }
   </header>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -12,10 +12,9 @@
           <a href="#">Merch</a>
           <a routerLink="/menu">Menu</a>
           <a routerLink="/drinks">Drinks</a>
-          <a routerLink="/calendar">Calendar</a>
         </div>
         <div class="nav-right">
-          <a href="#">Events</a>
+          <a href="/calendar">Events</a>
           <a href="#">Hours</a>
           <a href="#">Contact</a>
         </div>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,10 +3,12 @@ import { Home } from './home';
 import { Calenders } from './calenders';
 import { MenuComponent } from './pages/menu/menu';
 import { DrinksComponent } from './pages/drinks/drinks';
+import { CalendarComponent } from './pages/calendar/calendar';
 
 export const routes: Routes = [
   { path: '', component: Home },
   { path: 'calenders', component: Calenders },
+  { path: 'calendar', component: CalendarComponent },
   { path: 'menu', component: MenuComponent },
   { path: 'drinks', component: DrinksComponent },
 

--- a/src/app/pages/calendar/calendar.css
+++ b/src/app/pages/calendar/calendar.css
@@ -1,5 +1,28 @@
-.calendar-container {
-  display: flex;
-  justify-content: center;
-  margin-top: 1rem;
+body, html {
+  height: 60%;
+  margin: 0;
 }
+
+.page-content {
+  min-height: 100vh; /* full height */
+  display: flex;
+  justify-content: center; /* horizontal center */
+  align-items: center;     /* vertical center */
+  flex-direction: column;
+  padding: 0rem;
+   color:rgba(236, 230, 133, 0.913);
+   font-size: 3rem;
+}
+
+.calendar-container {
+  width: 150%;
+  max-width: 1800px;
+}
+
+.calendar-frame {
+  width: 100%;
+  height: 900px;
+  border: none;
+  border-radius: 10px;
+}
+

--- a/src/app/pages/calendar/calendar.css
+++ b/src/app/pages/calendar/calendar.css
@@ -1,0 +1,5 @@
+.calendar-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}

--- a/src/app/pages/calendar/calendar.html
+++ b/src/app/pages/calendar/calendar.html
@@ -1,11 +1,9 @@
-<h2>Upcoming Events</h2>
-<div class="calendar-container">
-  <iframe
-    src="https://calendar.google.com/calendar/embed?src=en.usa%23holiday%40group.v.calendar.google.com&ctz=America%2FDenver"
-    style="border: 0"
-    width="800"
-    height="600"
-    frameborder="0"
-    scrolling="no"
-  ></iframe>
+<div class="page-content">
+  <h2>Upcoming Events</h2>
+  <div class="calendar-container">
+    <iframe
+      src="https://calendar.google.com/calendar/embed?src=en.usa%23holiday%40group.v.calendar.google.com&ctz=America%2FDenver"
+      class="calendar-frame">
+    </iframe>
+  </div>
 </div>

--- a/src/app/pages/calendar/calendar.html
+++ b/src/app/pages/calendar/calendar.html
@@ -1,0 +1,11 @@
+<h2>Upcoming Events</h2>
+<div class="calendar-container">
+  <iframe
+    src="https://calendar.google.com/calendar/embed?src=en.usa%23holiday%40group.v.calendar.google.com&ctz=America%2FDenver"
+    style="border: 0"
+    width="800"
+    height="600"
+    frameborder="0"
+    scrolling="no"
+  ></iframe>
+</div>

--- a/src/app/pages/calendar/calendar.ts
+++ b/src/app/pages/calendar/calendar.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-calendar',
+  standalone: true,
+  imports: [],
+  templateUrl: './calendar.html',
+  styleUrl: './calendar.css',
+})
+export class CalendarComponent {}


### PR DESCRIPTION
## Summary
- add new CalendarComponent for Google Calendar embed
- register calendar route
- link calendar page from navigation

## Testing
- `npm test` *(fails: Module './drinks' has no exported member 'Drinks')*

------
https://chatgpt.com/codex/tasks/task_e_684f2fbb48b48327afc509bafec11c5a